### PR TITLE
Allow bigwig creation for RNA-seq; Fixed cluster memory allocation

### DIFF
--- a/cluster.json
+++ b/cluster.json
@@ -4,7 +4,6 @@
         "queue"     : "premium",
         "allocation": "acc_yourlab",
         "tasks"        : 1,
-        "memory"    : 12000,
         "resources" : "\"rusage[mem=12000] span[hosts=1]\"",
         "jobname"      : "{rule}.{wildcards}",
         "output"    : "output/logs/{rule}.{wildcards}.o",
@@ -14,23 +13,25 @@
 
     "trim_fastq_fastqc" :
     {
+        "resources" : "\"rusage[mem=24000] span[hosts=1]\"",
         "walltime"    : "10:00"
     },
 
     "fastq_to_bam_HISAT" :
     {
-        "memory"    : 24000,
+        "resources" : "\"rusage[mem=24000] span[hosts=1]\"",
         "walltime"    : "10:00"
     },
 
     "bam_to_unique_mapped":
     {
-        "memory"    : 24000,
+        "resources" : "\"rusage[mem=24000] span[hosts=1]\"",
         "walltime" : "06:00"
     },
 
     "sortedbam_to_rmdup":
     {
+        "resources" : "\"rusage[mem=24000] span[hosts=1]\"",
         "walltime"    : "04:00"
     },
 
@@ -46,7 +47,7 @@
 
     "chrbam_to_bw":
     {
-        "memory"    : 24000,
+        "resources" : "\"rusage[mem=24000] span[hosts=1]\"",
         "walltime"    : "02:00"
     },
 

--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ UMI_read1_pattern: "X"
 UMI_read2_pattern: "NNNNNNNN"
 ## See https://umi-tools.readthedocs.io/en/latest/ for informaton on "umi_tools extract" parameters
 
-# FOR CUT&RUN AND CHIPSEQ -
+# FOR CUT&RUN, CHIPSEQ, and RNASEQ (if you wish to generate bigwigs for RNASEQ)
 chr_sizes: "/path/to/mm10/mm10.chrom.sizes" # path to chrom.sizes file (only for chipseq)
 # This file must named as follows "<genomeid>.chrom.sizes", any other filename format (e.g. "mm10_chr_len") will
 # cause the TDF step to produce an empty TDF. Please see the Broad website for more information:


### PR DESCRIPTION
Allowed bigwig creation for RNA-seq. Fixed memory allocation on the cluster.json. Updated details on the config.yaml. Cleaned up the line breaks on the Snakefile.